### PR TITLE
Initialize Home and About Pages

### DIFF
--- a/src/personalwebsite/personalwebsite/settings.py
+++ b/src/personalwebsite/personalwebsite/settings.py
@@ -54,7 +54,7 @@ ROOT_URLCONF = 'personalwebsite.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/src/personalwebsite/personalwebsite/urls.py
+++ b/src/personalwebsite/personalwebsite/urls.py
@@ -17,6 +17,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from . import views
+
 urlpatterns = [
+    path('', views.home_page),
+    path('about/', views.about_page),
     path('admin/', admin.site.urls),
 ]

--- a/src/personalwebsite/personalwebsite/views.py
+++ b/src/personalwebsite/personalwebsite/views.py
@@ -1,0 +1,14 @@
+from django.shortcuts import render
+
+
+def home_page(request, *args, **kwargs):
+    context = {
+        "title": "Home"
+    }
+    return render(request, "home.html", context)
+
+def about_page(request, *args, **kwargs):
+    context = {
+        "title": "About"
+    }
+    return render(request, "about.html", context)

--- a/src/personalwebsite/templates/about.html
+++ b/src/personalwebsite/templates/about.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title%}
+{{ title }} - {{ block.super }}
+{% endblock %}
+
+{% block content %}
+<p>This is the {{ title }} page</p>
+{% endblock %}

--- a/src/personalwebsite/templates/base.html
+++ b/src/personalwebsite/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>
+        
+        {% block title %}
+        Cole Landolt
+        {% endblock %}
+
+    </title>
+</head>
+<body>
+
+    {% block content %}
+
+    {% endblock %}
+
+</body>
+</html>

--- a/src/personalwebsite/templates/home.html
+++ b/src/personalwebsite/templates/home.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title%}
+{{ title }} - {{ block.super }}
+{% endblock %}
+
+{% block content %}
+<p>This is the {{ title }} page</p>
+{% endblock %}


### PR DESCRIPTION
## Description

- Creates new templates for the home and about pages in `src/templates/`
- Adds the templates directory to `src/personalwebsite/settings.py`
- Creates new views for the home and about pages in `src/personalwebsite/views.py`
- Adds the paths for the home and about pages to `src/personalwebsite/urls.py`

## Validation

- `python manage.py runserver`